### PR TITLE
Updated config-template.json

### DIFF
--- a/src/config-template.json
+++ b/src/config-template.json
@@ -9,7 +9,7 @@
     },
     "runtime": {
         "arguments": "",
-        "version": "beta"
+        "version": "stable"
     },
     "shortcut": {
         "company": "OpenFin",


### PR DESCRIPTION
Switched `version` from `beta` to `stable`.  The beta option causes issues when being run on MacOS as the beta version is usually not available for it.  Also, do we really want to start people out on `beta`?