### PR TITLE
feat: retain indent style after update

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "OpenFin"
   ],
   "dependencies": {
+    "detect-indent": "^5.0.0",
     "lodash": "^2.4.1",
     "q": "^1.1.2"
   },

--- a/src/config-builder.js
+++ b/src/config-builder.js
@@ -4,8 +4,16 @@ var configWritter = require('./config-writter'),
     _ = require('lodash'),
     template = require('./config-template.json');
 
-function create(options, configPath, baseConfig) {
-    var config = baseConfig || template;
+function getIndentStyle(options) {
+    if (options == null || options.indent == null) {
+        return '    ';
+    }
+    return options.indent;
+}
+
+function create(options, configPath, baseConfig, indentOptions) {
+    var config = baseConfig || template,
+        indentStyle = getIndentStyle(indentOptions);
 
     //extend config the options object
     _.chain(options)
@@ -25,7 +33,7 @@ function create(options, configPath, baseConfig) {
         config.startup_app.uuid = config.startup_app.name + '-' + Math.random().toString(36).substring(2);
     }
 
-    return configWritter.write(config, configPath);
+    return configWritter.write(config, configPath, indentStyle);
 }
 
 module.exports = {

--- a/src/config-updater.js
+++ b/src/config-updater.js
@@ -3,7 +3,8 @@
 var configBuilder = require('./config-builder.js'),
     fs = require('fs'),
     path = require('path'),
-    Q = require('q');
+    Q = require('q'),
+    detectIndent = require('detect-indent');
 
 function update(options, configPath) {
     //update app.json with user propmts
@@ -16,9 +17,12 @@ function update(options, configPath) {
                 if (err) {
                     deffered.reject(new Error(err));
                 }
-                var appConfig = JSON.parse(data);
 
-                deffered.resolve(configBuilder.create(options, configPath, appConfig));
+                var dataStr = data.toString('utf8'),
+                    appConfig = JSON.parse(dataStr),
+                    indentOptions = detectIndent(dataStr);
+
+                deffered.resolve(configBuilder.create(options, configPath, appConfig, indentOptions));
             });
         } else {
             deffered.reject(new Error('File not found in: ' + configFilePath));

--- a/src/config-writter.js
+++ b/src/config-writter.js
@@ -4,11 +4,11 @@ var fs = require('fs'),
     path = require('path'),
     Q = require('q');
 
-function write(config, configPath) {
+function write(config, configPath, indentStyle) {
     var configFilePath = path.resolve(configPath),
         deffered = Q.defer();
 
-    fs.writeFile(configFilePath, JSON.stringify(config, null, '    '), function(err) {
+    fs.writeFile(configFilePath, JSON.stringify(config, null, indentStyle), function(err) {
         if (err) {
             deffered.reject(new Error(err));
         } else {


### PR DESCRIPTION
Uses the [`detect-indent`](https://github.com/sindresorhus/detect-indent) package to retain a user's preferred indentation style when `.update()` is called. 
